### PR TITLE
Add permission to bypass max alt account checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Permissions
 * mcbans.ban.temp (default: op) - Allow temp ban player
 * mcbans.ban.rollback (default: op) - Allow use rban command
 * mcbans.ban.ip (default: op) - Allow use banip command
+* mcbans.ban.exempt (default: op) - Permission to exempt from bans
 * mcbans.unban (default: op) - Allow unban player
 * mcbans.view.alts (default: op) - Show notification of a players alts on connect
 * mcbans.view.bans (default: op) - Show previous ban information on player connect
@@ -78,3 +79,7 @@ Permissions
 * mcbans.lookup.ban (default: op) - Allow lookup ban details
 * mcbans.lookup.alt (default: op) - Allow lookup alt account
 * mcbans.kick (default: op) - Allow kick player
+* mcbans.kick.exempt (default: op) - Permission to exempt from kicks
+* mcbans.maxalts.exempt (default: op) - Permission to exempt from max alt account disconnect
+
+

--- a/src/com/mcbans/firestar/mcbans/bukkitListeners/PlayerListener.java
+++ b/src/com/mcbans/firestar/mcbans/bukkitListeners/PlayerListener.java
@@ -412,7 +412,6 @@ public class PlayerListener implements Listener {
                 return;
             }
             // check alternate accounts
-            //TODO
             else if (config.isEnableMaxAlts() && config.getMaxAlts() < Integer.valueOf(s[3]) && Perms.EXEMPT_MAXALTS.has(event.getName())) {
                 event.disallow(Result.KICK_BANNED, _("overMaxAlts"));
                 return;

--- a/src/com/mcbans/firestar/mcbans/bukkitListeners/PlayerListener.java
+++ b/src/com/mcbans/firestar/mcbans/bukkitListeners/PlayerListener.java
@@ -412,7 +412,7 @@ public class PlayerListener implements Listener {
                 return;
             }
             // check alternate accounts
-            else if (config.isEnableMaxAlts() && config.getMaxAlts() < Integer.valueOf(s[3]) && Perms.EXEMPT_MAXALTS.has(event.getName())) {
+            else if (config.isEnableMaxAlts() && config.getMaxAlts() < Integer.valueOf(s[3]) && !Perms.EXEMPT_MAXALTS.has(event.getName())) {
                 event.disallow(Result.KICK_BANNED, _("overMaxAlts"));
                 return;
             }

--- a/src/com/mcbans/firestar/mcbans/bukkitListeners/PlayerListener.java
+++ b/src/com/mcbans/firestar/mcbans/bukkitListeners/PlayerListener.java
@@ -412,7 +412,8 @@ public class PlayerListener implements Listener {
                 return;
             }
             // check alternate accounts
-            else if (config.isEnableMaxAlts() && config.getMaxAlts() < Integer.valueOf(s[3])) {
+            //TODO
+            else if (config.isEnableMaxAlts() && config.getMaxAlts() < Integer.valueOf(s[3]) && Perms.EXEMPT_MAXALTS.has(event.getName())) {
                 event.disallow(Result.KICK_BANNED, _("overMaxAlts"));
                 return;
             }

--- a/src/com/mcbans/firestar/mcbans/permission/Perms.java
+++ b/src/com/mcbans/firestar/mcbans/permission/Perms.java
@@ -37,6 +37,7 @@ public enum Perms {
     // Exempt
     EXEMPT_KICK     ("kick.exempt"),
     EXEMPT_BAN      ("ban.exempt"),
+    EXEMPT_MAXALTS	("maxalts.exempt"),
 
     // Others
     LOOKUP_PLAYER   ("lookup.player"),


### PR DESCRIPTION
Adds a permission to exempt a player from being disconnected on login due to too many alts. This helps dramatically reduce the effectiveness of spambots such as pwnage and darkbot while not breaking functionality for legitimate players who just happened to use a proxy or VPN. Additionally, this allows owners to stress test their server with specified accounts without disabling the max alt account feature and leaving their server vulnerable.