### PR TITLE
Fix players with unresolved IP addresses from being unkickable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,8 @@
 	</properties>
 	<repositories>
         <repository>
-            <id>bukkit-repo</id>
-            <url>http://repo.bukkit.org/content/groups/public</url>
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
         <repository>
             <id>sk89q-mvn2</id>
@@ -36,12 +36,8 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.7.9-R0.3-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-            <groupId>org.bukkit</groupId>
-            <artifactId>craftbukkit</artifactId>
-            <version>1.7.9-R0.3-SNAPSHOT</version>
+            <version>1.9.4-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
         </dependency>
 		<dependency>
 	       <groupId>uk.co.oliwali</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,8 +24,8 @@
             <url>http://repo.comphenix.net/content/groups/public</url>
         </repository>
         <repository>
-            <id>md_5-rep</id>
-            <url>http://repo.md-5.net/content/repositories/releases</url>
+            <id>md_5-snapshots</id>
+            <url>http://repo.md-5.net/content/repositories/snapshots/</url>
         </repository>
 		<repository>
             <id>ci-synload</id>
@@ -68,9 +68,9 @@
 		   <systemPath>${basedir}/lib/CoreProtect_2.0.9.jar</systemPath>
 	    </dependency>
 		<dependency>
-	       <groupId>de.diddiz</groupId>
-	       <artifactId>logblock</artifactId>
-	       <version>dev-SNAPSHOT</version>
+            <groupId>de.diddiz</groupId>
+            <artifactId>logblock</artifactId>
+            <version>1.10.1-SNAPSHOT</version>
 	    </dependency>
 	</dependencies>
 	<build>

--- a/src/com/mcbans/firestar/mcbans/commands/BaseCommand.java
+++ b/src/com/mcbans/firestar/mcbans/commands/BaseCommand.java
@@ -2,6 +2,7 @@ package com.mcbans.firestar.mcbans.commands;
 
 import static com.mcbans.firestar.mcbans.I18n._;
 
+import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -93,8 +94,14 @@ public abstract class BaseCommand {
             // get targetIP if available
             final Player targetPlayer = Bukkit.getPlayerExact(target);
             if (targetPlayer != null && targetPlayer.isOnline()){
-                targetIP = targetPlayer.getAddress().getAddress().getHostAddress();
-                //targetUUID = targetPlayer.getUniqueId().toString();
+                InetSocketAddress socket = targetPlayer.getAddress();
+                //Not all IPs are succcessfully resolved
+                //This prevents players from being unbannable/kickable in this rare case
+                if(socket.isUnresolved()) {
+                    targetIP = socket.getHostString();
+                } else {
+                    targetIP = socket.getAddress().getHostAddress();
+                }
             }
             // check isValid player name
             if (!Util.isValidName(target)){


### PR DESCRIPTION
Some players have IP addresses that are unresolvable. When the corresponding InetSocketAddress object had .getAddress() called on it, it would return null and cause the issued kick/ban commands to fail. In these cases, the players would be immune to MCBans. This PR contains a fix that checks to see if the IP was resolved, and in the cases where it wasn't it makes a best effort attempt to still get the player's IP.