### PR TITLE
fix events called with async

### DIFF
--- a/src/main/java/com/mcbans/plugin/events/PlayerBanEvent.java
+++ b/src/main/java/com/mcbans/plugin/events/PlayerBanEvent.java
@@ -2,6 +2,7 @@ package com.mcbans.plugin.events;
 
 import java.util.UUID;
 
+import org.bukkit.Bukkit;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -13,6 +14,8 @@ public class PlayerBanEvent extends Event implements Cancellable {
     private String duration, measure, reason, sender, playerIP, player, playerUUID, senderUUID;
 
     public PlayerBanEvent(String player, String playerUUID, String playerIP, String sender, String senderUUID, String reason, int action_id, String duration, String measure) {
+        super(!Bukkit.isPrimaryThread());
+
         this.player = player;
         this.playerIP = playerIP;
         this.sender = sender;

--- a/src/main/java/com/mcbans/plugin/events/PlayerGlobalBanEvent.java
+++ b/src/main/java/com/mcbans/plugin/events/PlayerGlobalBanEvent.java
@@ -2,6 +2,7 @@ package com.mcbans.plugin.events;
 
 import java.util.UUID;
 
+import org.bukkit.Bukkit;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -16,6 +17,8 @@ public class PlayerGlobalBanEvent extends Event implements Cancellable {
     private String reason, playerUUID, senderUUID;
 
     public PlayerGlobalBanEvent(String player, String playerUUID, String playerIP, String sender, String senderUUID, String reason) {
+        super(!Bukkit.isPrimaryThread());
+
         this.player = player;
         this.playerIP = playerIP;
         this.sender = sender;

--- a/src/main/java/com/mcbans/plugin/events/PlayerIPBanEvent.java
+++ b/src/main/java/com/mcbans/plugin/events/PlayerIPBanEvent.java
@@ -2,6 +2,7 @@ package com.mcbans.plugin.events;
 
 import java.util.UUID;
 
+import org.bukkit.Bukkit;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -15,6 +16,8 @@ public class PlayerIPBanEvent extends Event implements Cancellable {
     private String reason, senderUUID;
 
     public PlayerIPBanEvent(String ip, String sender, String senderUUID, String reason) {
+        super(!Bukkit.isPrimaryThread());
+
         this.ip = ip;
         this.sender = sender;
         this.senderUUID = senderUUID;

--- a/src/main/java/com/mcbans/plugin/events/PlayerIPBannedEvent.java
+++ b/src/main/java/com/mcbans/plugin/events/PlayerIPBannedEvent.java
@@ -2,6 +2,7 @@ package com.mcbans.plugin.events;
 
 import java.util.UUID;
 
+import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
@@ -13,6 +14,8 @@ public class PlayerIPBannedEvent extends Event {
     private String reason, senderUUID;
 
     public PlayerIPBannedEvent(String ip, String sender, String senderUUID, String reason) {
+        super(!Bukkit.isPrimaryThread());
+
         this.ip = ip;
         this.sender = sender;
         this.reason = reason;

--- a/src/main/java/com/mcbans/plugin/events/PlayerKickEvent.java
+++ b/src/main/java/com/mcbans/plugin/events/PlayerKickEvent.java
@@ -2,6 +2,7 @@ package com.mcbans.plugin.events;
 
 import java.util.UUID;
 
+import org.bukkit.Bukkit;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -15,6 +16,8 @@ public class PlayerKickEvent extends Event implements Cancellable {
     private String reason, playerUUID, senderUUID;
 
     public PlayerKickEvent(String player, String playerUUID, String sender, String senderUUID, String reason) {
+        super(!Bukkit.isPrimaryThread());
+
         this.player = player;
         this.sender = sender;
         this.reason = reason;

--- a/src/main/java/com/mcbans/plugin/events/PlayerLocalBanEvent.java
+++ b/src/main/java/com/mcbans/plugin/events/PlayerLocalBanEvent.java
@@ -2,6 +2,7 @@ package com.mcbans.plugin.events;
 
 import java.util.UUID;
 
+import org.bukkit.Bukkit;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -16,6 +17,8 @@ public class PlayerLocalBanEvent extends Event implements Cancellable {
     private String reason, playerUUID, senderUUID;
 
     public PlayerLocalBanEvent(String player, String playerUUID, String playerIP, String sender, String senderUUID, String reason) {
+        super(!Bukkit.isPrimaryThread());
+
         this.player = player;
         this.playerIP = playerIP;
         this.playerUUID = playerUUID;

--- a/src/main/java/com/mcbans/plugin/events/PlayerTempBanEvent.java
+++ b/src/main/java/com/mcbans/plugin/events/PlayerTempBanEvent.java
@@ -2,6 +2,7 @@ package com.mcbans.plugin.events;
 
 import java.util.UUID;
 
+import org.bukkit.Bukkit;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -18,6 +19,8 @@ public class PlayerTempBanEvent extends Event implements Cancellable {
     private String measure, playerUUID, senderUUID;
 
     public PlayerTempBanEvent(String player, String playerUUID, String playerIP, String sender, String senderUUID, String reason, String duration, String measure) {
+        super(!Bukkit.isPrimaryThread());
+
         this.player = player;
         this.playerIP = playerIP;
         this.sender = sender;

--- a/src/main/java/com/mcbans/plugin/events/PlayerUnbanEvent.java
+++ b/src/main/java/com/mcbans/plugin/events/PlayerUnbanEvent.java
@@ -3,6 +3,7 @@ package com.mcbans.plugin.events;
 import java.util.UUID;
 
 import com.mcbans.plugin.util.Util;
+import org.bukkit.Bukkit;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
@@ -15,6 +16,8 @@ public class PlayerUnbanEvent extends Event implements Cancellable {
     private String sender,senderUUID;
 
     public PlayerUnbanEvent(String target, String targetUUID, String sender, String senderUUID) {
+        super(!Bukkit.isPrimaryThread());
+
         this.target = target;
         this.sender = sender;
         this.senderUUID = senderUUID;

--- a/src/main/java/com/mcbans/plugin/events/PlayerUnbannedEvent.java
+++ b/src/main/java/com/mcbans/plugin/events/PlayerUnbannedEvent.java
@@ -2,6 +2,7 @@ package com.mcbans.plugin.events;
 
 import java.util.UUID;
 
+import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
@@ -12,6 +13,8 @@ public class PlayerUnbannedEvent extends Event {
     private String sender, senderUUID, playerUUID;
 
     public PlayerUnbannedEvent(String player, String playerUUID, String sender, String senderUUID) {
+        super(!Bukkit.isPrimaryThread());
+
         this.player = player;
         this.sender = sender;
         this.senderUUID = senderUUID;

--- a/src/main/java/com/mcbans/plugin/request/Ban.java
+++ b/src/main/java/com/mcbans/plugin/request/Ban.java
@@ -195,7 +195,7 @@ public class Ban {
                 }
                 Util.broadcastMessage(ChatColor.GREEN + localize("unBanSuccess", I18n.PLAYER, playerName, I18n.SENDER, senderName));
 
-                Bukkit.getScheduler().runTaskLater(plugin, ()->plugin.getServer().getPluginManager().callEvent(new PlayerUnbannedEvent(playerName, playerUUID, senderName, senderUUID)), 1);
+                plugin.getServer().getPluginManager().callEvent(new PlayerUnbannedEvent(playerName, playerUUID, senderName, senderUUID));
 
                 log.info(senderName + " unbanned " + playerName + "!");
                 return;
@@ -258,7 +258,7 @@ public class Ban {
 
                     Util.broadcastMessage(ChatColor.GREEN + localize("localBanSuccess", I18n.PLAYER, playerName, I18n.SENDER, senderName, I18n.REASON, reason, I18n.IP, playerIP));
 
-                    Bukkit.getScheduler().runTaskLater(plugin, ()->plugin.getServer().getPluginManager().callEvent(new PlayerBanEvent(playerName, playerUUID, playerIP, senderName, senderUUID, reason, action_id, duration, measure)), 1);
+                    plugin.getServer().getPluginManager().callEvent(new PlayerBanEvent(playerName, playerUUID, playerIP, senderName, senderUUID, reason, action_id, duration, measure));
 
                     log.info(playerName + " has been banned with a local type ban [" + reason + "] [" + senderName + "]!");
                     return;
@@ -328,7 +328,7 @@ public class Ban {
                     this.kickPlayer(playerName, playerUUID, localize("globalBanPlayer", I18n.PLAYER, playerName, I18n.SENDER, senderName, I18n.REASON, reason, I18n.IP, playerIP));
                     Util.broadcastMessage(ChatColor.GREEN + localize("globalBanSuccess", I18n.PLAYER, playerName, I18n.SENDER, senderName, I18n.REASON, reason, I18n.IP, playerIP));
 
-                    Bukkit.getScheduler().runTaskLater(plugin, () -> plugin.getServer().getPluginManager().callEvent(new PlayerBanEvent(playerName, playerUUID, playerIP, senderName, senderUUID, reason, action_id, duration, measure)), 1);
+                    plugin.getServer().getPluginManager().callEvent(new PlayerBanEvent(playerName, playerUUID, playerIP, senderName, senderUUID, reason, action_id, duration, measure));
 
                     log.info(playerName + " has been banned with a global type ban [" + reason + "] [" + senderName + "]!");
                     return;
@@ -401,7 +401,7 @@ public class Ban {
                     this.kickPlayer(playerName, playerUUID, localize("tempBanPlayer", I18n.PLAYER, playerName, I18n.SENDER, senderName, I18n.REASON, reason, I18n.IP, playerIP));
                     Util.broadcastMessage(ChatColor.GREEN + localize("tempBanSuccess", I18n.PLAYER, playerName, I18n.SENDER, senderName, I18n.REASON, reason, I18n.IP, playerIP));
 
-                    Bukkit.getScheduler().runTaskLater(plugin, ()->plugin.getServer().getPluginManager().callEvent(new PlayerBanEvent(playerName, playerUUID, playerIP, senderName, senderUUID, reason, action_id, duration, measure)),1);
+                    plugin.getServer().getPluginManager().callEvent(new PlayerBanEvent(playerName, playerUUID, playerIP, senderName, senderUUID, reason, action_id, duration, measure));
 
                     log.info(playerName + " has been banned with a temp type ban [" + reason + "] [" + senderName + "]!");
                     return;

--- a/src/main/java/com/mcbans/plugin/request/BanIpRequest.java
+++ b/src/main/java/com/mcbans/plugin/request/BanIpRequest.java
@@ -68,7 +68,7 @@ public class BanIpRequest extends BaseRequest<MessageCallback>{
                         kickPlayerByIP(this.ip, reason);
 
                         log.info("IP " + ip + " has been banned [" + reason + "] [" + issuedBy + "]!");
-                        plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, ()->plugin.getServer().getPluginManager().callEvent(new PlayerIPBannedEvent(ip, issuedBy, issuedByUUID, reason)), 0L);
+                        plugin.getServer().getPluginManager().callEvent(new PlayerIPBannedEvent(ip, issuedBy, issuedByUUID, reason));
                     }else if (result.equals("a")){
                         // equals("a") if already banned ip
                         callback.error(ChatColor.RED + localize("ipBanAlready", I18n.IP, this.ip, I18n.SENDER, this.issuedBy, I18n.REASON, this.reason));


### PR DESCRIPTION
This PR will fix #108 .

Primary thread check in events constructor.
After this change, use `PluginManager#callEvent` any timings will not occur any errors. 