### PR TITLE
Fixed ClassCastException and updated Gradle repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,16 +15,18 @@ repositories {
     maven {
         url 'http://repo.md-5.net/content/repositories/snapshots/'
     }
-    maven {
-        url 'http://ci.synload.com/plugin/repository/everything/'
-    }
+    // Spigot API
     maven {
         url 'https://hub.spigotmc.org/nexus/content/repositories/snapshots/'
+    }
+    // Bungeecord API
+    maven {
+        url 'https://oss.sonatype.org/content/repositories/snapshots'
     }
 }
 
 dependencies {
-    compile group: 'org.bukkit', name: 'bukkit', version: '1.14.4-R0.1-SNAPSHOT'
+    compile group: 'org.bukkit', name: 'bukkit', version: '1.15.2-R0.1-SNAPSHOT'
     compile group: 'de.diddiz', name: 'logblock', version: '1.13.1-SNAPSHOT'
     compile fileTree(dir: 'libs', include: ['*.jar'])
 }

--- a/src/main/java/com/mcbans/plugin/commands/BaseCommand.java
+++ b/src/main/java/com/mcbans/plugin/commands/BaseCommand.java
@@ -180,13 +180,15 @@ public abstract class BaseCommand {
 
     private void check() throws CommandException {
         if(banning) {
-            if(targetUUID.isEmpty()) {
-                if (!Util.checkVault((Player) sender, Bukkit.getOfflinePlayer(target))) {
-                    throw new CommandException(ChatColor.RED + localize("permissionDenied"));
-                }
-            } else {
-                if (!Util.checkVault((Player) sender, Bukkit.getOfflinePlayer(UUID.fromString(targetUUID)))) {
-                    throw new CommandException(ChatColor.RED + localize("permissionDenied"));
+            if (sender instanceof Player) {
+                if(targetUUID.isEmpty()) {
+                    if (!Util.checkVault((Player) sender, Bukkit.getOfflinePlayer(target))) {
+                        throw new CommandException(ChatColor.RED + localize("permissionDenied"));
+                    }
+                } else {
+                    if (!Util.checkVault((Player) sender, Bukkit.getOfflinePlayer(UUID.fromString(targetUUID)))) {
+                        throw new CommandException(ChatColor.RED + localize("permissionDenied"));
+                    }
                 }
             }
         }


### PR DESCRIPTION
With version 4.5.1 of MCBans, you will get a ClassCastException when attempting to ban a player over the console. This was due to the changes with priorities, where the command sender is cast to a player without it being checked if it was a player first.  With this pull request, the console is automatically assumed to be a higher priority than all players.

In addition to this change, I removed the `http://ci.synload.com/plugin/repository/everything/` repository from the build.gradle file (which seemed to be down/has security problems?) as it prevented building the jar file on my end.  